### PR TITLE
Redirect to install view if not installed

### DIFF
--- a/app/Http/Controllers/InstallController.php
+++ b/app/Http/Controllers/InstallController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class InstallController extends Controller
+{
+    public function index() : View {
+        return view('installer.index');
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -59,6 +59,7 @@ class Kernel extends HttpKernel
         'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
+        'installed' => \App\Http\Middleware\RedirectIfNotInstalled::class,
         'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,

--- a/app/Http/Middleware/RedirectIfNotInstalled.php
+++ b/app/Http/Middleware/RedirectIfNotInstalled.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RedirectIfNotInstalled
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (!env("DB_DATABASE")) {
+            return redirect(route('install'));
+        }
+
+        return $next($request);
+    }
+}

--- a/resources/views/installer/index.blade.php
+++ b/resources/views/installer/index.blade.php
@@ -1,0 +1,1 @@
+Hello Installer!

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,7 +12,8 @@ use Illuminate\Support\Facades\Route;
 | be assigned to the "web" middleware group. Make something great!
 |
 */
+Route::get('/install', [App\Http\Controllers\InstallController::class, 'index'])->name('install');
 
-Route::get('/', function () {
-    return view('welcome');
+Route::middleware('installed')->group(function() {
+    Route::get('/', fn() => view('welcome'));
 });


### PR DESCRIPTION
If there is no DB_DATABASE field set, the app will auto redirect to the installation process. 

Custom middleware added for this